### PR TITLE
Update lib.rs

### DIFF
--- a/src/icp_rust_boilerplate_backend/src/lib.rs
+++ b/src/icp_rust_boilerplate_backend/src/lib.rs
@@ -1,11 +1,11 @@
 #[macro_use]
 extern crate serde;
 use candid::{Decode, Encode};
-use ic_cdk::api::time;
+use ic_cdk::api::{time, logging};
 use ic_stable_structures::memory_manager::{MemoryId, MemoryManager, VirtualMemory};
 use ic_stable_structures::{BoundedStorable, Cell, DefaultMemoryImpl, StableBTreeMap, Storable};
 use std::{borrow::Cow, cell::RefCell};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 type Memory = VirtualMemory<DefaultMemoryImpl>;
 type IdCell = Cell<u64, Memory>;
@@ -20,38 +20,36 @@ struct Quiz {
     updated_at: Option<u64>,
 }
 
-// a trait that must be implemented for a struct that is stored in a stable struct
 impl Storable for Quiz {
-    fn to_bytes(&self) -> std::borrow::Cow<[u8]> {
+    fn to_bytes(&self) -> Cow<[u8]> {
         Cow::Owned(Encode!(self).unwrap())
     }
 
-    fn from_bytes(bytes: std::borrow::Cow<[u8]>) -> Self {
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
         Decode!(bytes.as_ref(), Self).unwrap()
     }
 }
 
-// another trait that must be implemented for a struct that is stored in a stable struct
 impl BoundedStorable for Quiz {
     const MAX_SIZE: u32 = 1024;
     const IS_FIXED_SIZE: bool = false;
 }
 
 thread_local! {
-        static MEMORY_MANAGER: RefCell<MemoryManager<DefaultMemoryImpl>> = RefCell::new(
-            MemoryManager::init(DefaultMemoryImpl::default())
-        );
+    static MEMORY_MANAGER: RefCell<MemoryManager<DefaultMemoryImpl>> = RefCell::new(
+        MemoryManager::init(DefaultMemoryImpl::default())
+    );
 
-        static ID_COUNTER: RefCell<IdCell> = RefCell::new(
-            IdCell::init(MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(0))), 0)
-                .expect("Cannot create a counter")
-        );
+    static ID_COUNTER: RefCell<IdCell> = RefCell::new(
+        IdCell::init(MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(0))), 0)
+            .expect("Cannot create a counter")
+    );
 
-        static STORAGE: RefCell<StableBTreeMap<u64, Quiz, Memory>> =
-            RefCell::new(StableBTreeMap::init(
-                MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(1)))
+    static STORAGE: RefCell<StableBTreeMap<u64, Quiz, Memory>> =
+        RefCell::new(StableBTreeMap::init(
+            MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(1)))
         ));
-    }
+}
 
 #[derive(candid::CandidType, Serialize, Deserialize, Default)]
 struct QuizPayload {
@@ -59,56 +57,47 @@ struct QuizPayload {
     options: Vec<String>,
 }
 
-
 #[ic_cdk::query]
 fn get_all_quiz() -> Result<Vec<Quiz>, Error> {
-    let quizzesMap : Vec<(u64, Quiz)> =  STORAGE.with(|service| service.borrow().iter().collect());
-    let length = quizzesMap.len();
-    let mut quizzes: Vec<Quiz> = Vec::new();
-    for key in 0..length {
-        quizzes.push(quizzesMap.get(key).unwrap().clone().1);
-    }
+    let quizzes: Vec<Quiz> = STORAGE.with(|service| service.borrow().values().cloned().collect());
 
-    if quizzes.len() > 0 {
-        Ok(quizzes)
-    }else {
+    if quizzes.is_empty() {
         Err(Error::NotFound {
-            msg: format!("There are currently no quiz"),
+            msg: "There are currently no quizzes.".to_string(),
         })
+    } else {
+        Ok(quizzes)
     }
 }
-
 
 #[ic_cdk::query]
 fn get_quiz(id: u64) -> Result<Quiz, Error> {
     match _get_quiz(&id) {
-        Some(message) => Ok(message),
+        Some(quiz) => Ok(quiz.clone()),
         None => Err(Error::NotFound {
-            msg: format!("a quiz with id={} not found", id),
+            msg: format!("A quiz with id={} not found", id),
         }),
     }
 }
 
 fn _get_quiz(id: &u64) -> Option<Quiz> {
-    STORAGE.with(|s| s.borrow().get(id))
+    STORAGE.with(|s| s.borrow().get(id).cloned())
 }
 
-
 #[ic_cdk::update]
-fn create_quiz(payload: QuizPayload) -> Option<Quiz> {
+fn create_quiz(payload: QuizPayload) -> Result<Quiz, Error> {
     let id = ID_COUNTER
         .with(|counter| {
             let current_value = *counter.borrow().get();
             counter.borrow_mut().set(current_value + 1)
         })
-        .expect("cannot increment id counter");
+        .map_err(|_| Error::CounterIncrementFailed)?;
 
     let mut answers = HashMap::new();
 
     for option in &payload.options {
-        answers.insert(String::from(option), 0);
+        answers.insert(option.clone(), 0);
     }
-
 
     let quiz = Quiz {
         id,
@@ -119,100 +108,77 @@ fn create_quiz(payload: QuizPayload) -> Option<Quiz> {
         updated_at: None,
     };
     do_insert(&quiz);
-    Some(quiz)
+    Ok(quiz)
 }
 
-
-// helper method to perform insert.
 fn do_insert(quiz: &Quiz) {
     STORAGE.with(|service| service.borrow_mut().insert(quiz.id, quiz.clone()));
 }
 
-
 #[ic_cdk::update]
 fn update_quiz(id: u64, payload: QuizPayload) -> Result<Quiz, Error> {
-
-    let quiz_option: Option<Quiz> = STORAGE.with(|service| service.borrow().get(&id));
-
-    match quiz_option {
-
-        Some(mut quiz) => {
-
-
-            let mut answers = HashMap::new();
-
-            for option in &payload.options {
-                answers.insert(String::from(option), 0);
-            }
-
-            quiz.question = payload.question;
-            quiz.options = payload.options;
-            quiz.answers = answers;
-            quiz.updated_at = Some(time());
-            do_insert(&quiz);
-            Ok(quiz)
-        }
-        None => Err(Error::NotFound {
-            msg: format!(
-                "couldn't update a quiz with id={}. quiz not found",
-                id
-            ),
+    let mut quiz = match _get_quiz(&id) {
+        Some(q) => q,
+        None => return Err(Error::NotFound {
+            msg: format!("Couldn't update quiz with id={}. Quiz not found", id),
         }),
-    }
-}
+    };
 
+    let mut answers = HashMap::new();
+    for option in &payload.options {
+        answers.insert(option.clone(), 0);
+    }
+
+    quiz.question = payload.question;
+    quiz.options = payload.options;
+    quiz.answers = answers;
+    quiz.updated_at = Some(time());
+    do_insert(&quiz);
+    Ok(quiz)
+}
 
 #[ic_cdk::update]
 fn delete_quiz(id: u64) -> Result<Quiz, Error> {
     match STORAGE.with(|service| service.borrow_mut().remove(&id)) {
         Some(quiz) => Ok(quiz),
         None => Err(Error::NotFound {
-            msg: format!(
-                "couldn't delete a quiz with id={}. quiz not found.",
-                id
-            ),
+            msg: format!("Couldn't delete quiz with id={}. Quiz not found.", id),
         }),
     }
 }
 
-
 #[ic_cdk::update]
 fn answer_quiz(id: u64, option: String) -> Result<Quiz, Error> {
-
-    let quiz_option: Option<Quiz> = STORAGE.with(|service| service.borrow().get(&id));
-
-    match quiz_option {
-
-        Some(mut quiz) => {
-
-            // Check if the selected option is valid
-            if quiz.options.contains(&option) {
-                if let Some(answer_count) = quiz.answers.get_mut(&option) {
-                    *answer_count += 1;
-                }
-                quiz.updated_at = Some(time());
-                do_insert(&quiz);
-                Ok(quiz)
-            } else {
-                // Return an error if the selected option is not valid
-                Err(Error::NotFound {
-                    msg: format!("The option '{}' is not found for this quiz.", option),
-                })
-            }
-        }
-        None => Err(Error::NotFound {
-            msg: format!(
-                "couldn't cast a quiz with id={}. quiz not found",
-                id
-            ),
+    let mut quiz = match _get_quiz(&id) {
+        Some(q) => q,
+        None => return Err(Error::NotFound {
+            msg: format!("Couldn't answer quiz with id={}. Quiz not found.", id),
         }),
+    };
+
+    if !quiz.options.contains(&option) {
+        return Err(Error::InvalidAnswerOption {
+            msg: format!("The option '{}' is not found for this quiz.",
+option),
+        });
     }
+
+    if let Some(answer_count) = quiz.answers.get_mut(&option) {
+        *answer_count += 1;
+    }
+
+    quiz.updated_at = Some(time());
+    do_insert(&quiz);
+    Ok(quiz)
 }
 
 #[derive(candid::CandidType, Deserialize, Serialize)]
 enum Error {
     NotFound { msg: String },
+    CounterIncrementFailed,
+    InvalidAnswerOption { msg: String },
 }
 
-// need this to generate candid
+// Need this to generate Candid
 ic_cdk::export_candid!();
+```


### PR DESCRIPTION
Changes made:

1. Used `cloned()` to create a new vector in `get_all_quiz`.
2. Implemented suggestions for consistent error handling.
3. Used `option.clone()` to avoid cloning strings unnecessarily.
4. Added error handling for invalid answer options in `answer_quiz`.
5. Introduced an `InvalidAnswerOption` variant in the `Error` enum.
6. Made use of `cloned()` when getting a quiz from storage to avoid accidental mutations.
7. Improved error messages for better clarity.